### PR TITLE
Suse/SLES support

### DIFF
--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -11,16 +11,18 @@ class odbc::mysql {
     name   => $::odbc::params::mysql_pkg,
   }
 
-  $libpath = $::odbc::params::mysql_libpath
-  $libname = $::odbc::params::mysql_libname
+  $libpath     = $::odbc::params::mysql_libpath
+  $libname     = $::odbc::params::mysql_libname
+  $setupname   = $::odbc::params::mysql_setupname
+  $config_root = $::odbc::params::odbc_config_root
 
   augeas { 'mysql odbc driver config':
     lens    => 'Odbc.lns',
-    incl    => '/etc/odbcinst.ini',
+    incl    => "${config_root}/odbcinst.ini",
     changes => [
       "set MySQL/Description 'ODBC for MySQL'",
       "set MySQL/Driver ${libpath}/${libname}",
-      "set MySQL/Setup ${libpath}/libodbcmyS.so",
+      "set MySQL/Setup ${libpath}/${setupname}",
       'set MySQL/FileUsage 1',
     ],
     require => Package['mysql-odbc'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,17 @@ class odbc::params {
       $pgsql_pkg = 'odbc-postgresql'
     }
 
+    'Suse': {
+      $unixodbc_pkg = 'unixODBC'
+      $mysql_pkg   = 'MyODBC-unixODBC'
+      $mysql_libname = 'libmyodbc3.so'
+      $mysql_libpath = $::architecture ? {
+        'x86_64' => '/usr/lib64',
+        default  => '/usr/lib',
+      }
+      $pgsql_pkg = 'psqlODBC'
+    }
+
     default: {
       fail "Unsupported OS family ${::osfamily}"
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,9 +1,11 @@
 class odbc::params {
   case $::osfamily {
     'RedHat': {
+      $odbc_config_root = '/etc'
       $unixodbc_pkg = 'unixODBC'
       $mysql_pkg = 'mysql-connector-odbc'
       $mysql_libname = 'libmyodbc3.so'
+      $mysql_setupname = 'libmyodbcS.so'
       $mysql_libpath = $::architecture ? {
         'x86_64' => '/usr/lib64',
         default  => '/usr/lib',
@@ -12,17 +14,21 @@ class odbc::params {
     }
 
     'Debian': {
+      $odbc_config_root = '/etc'
       $unixodbc_pkg = 'unixodbc'
       $mysql_pkg = 'libmyodbc'
       $mysql_libname = 'libmyodbc.so'
+      $mysql_setupname = 'libmyodbcS.so'
       $mysql_libpath = '/usr/lib/odbc'
       $pgsql_pkg = 'odbc-postgresql'
     }
 
     'Suse': {
+      $odbc_config_root = '/etc/unixODBC'
       $unixodbc_pkg = 'unixODBC'
       $mysql_pkg   = 'MyODBC-unixODBC'
       $mysql_libname = 'libmyodbc3.so'
+      $mysql_setupname = 'libmyodbc3S.so'
       $mysql_libpath = $::architecture ? {
         'x86_64' => '/usr/lib64',
         default  => '/usr/lib',

--- a/metadata.json
+++ b/metadata.json
@@ -38,6 +38,12 @@
         "5",
         "6"
       ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "11"
+      ]
     }
   ],
   "puppet_version": [


### PR DESCRIPTION
Hi,

this adds basic support for Suse/SLES.

The first commit just adds the general support,
the second one adds two new OS dependent default parameters, $odbc_config_root and $mysql_setupname.

On SLES, the unixodbc config directory is /etc/unixODBC, and the setup name library also
has the 3 in the name, as opposed to the others.

please consider for merge, or let me know if there is something to change/fix/enhance.
